### PR TITLE
Searching Skill Trees and Quest Icons

### DIFF
--- a/app/src/main/java/com/ghstudios/android/data/database/DataManager.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/DataManager.java
@@ -824,6 +824,10 @@ public class DataManager {
 		return mHelper.querySkillTrees();
 	}
 
+	public SkillTreeCursor querySkillTreesSearch(String searchTerm) {
+		return mHelper.querySkillTreesSearch(searchTerm);
+	}
+
 	/* Get a specific SkillTree */
 	public SkillTree getSkillTree(long id) {
 		SkillTree skillTree = null;

--- a/app/src/main/java/com/ghstudios/android/data/database/MonsterHunterDatabaseHelper.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/MonsterHunterDatabaseHelper.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import android.content.ContentValues;
@@ -2385,7 +2386,7 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
         String q = "q";
         String l = "l";
 
-        HashMap<String, String> projectionMap = new HashMap<String, String>();
+        LinkedHashMap<String, String> projectionMap = new LinkedHashMap<String, String>();
 
         projectionMap.put("_id", q + "." + S.COLUMN_QUESTS_ID + " AS " + "_id");
         projectionMap.put(q + S.COLUMN_QUESTS_NAME, q + "." + S.COLUMN_QUESTS_NAME + " AS " + q + S.COLUMN_QUESTS_NAME);
@@ -2558,6 +2559,31 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
         qh.Having = null;
         qh.OrderBy = null;
         qh.Limit = null;
+
+        return new SkillTreeCursor(wrapHelper(qh));
+    }
+
+    /*
+     * Get Skill trees filtered by name
+     */
+    public SkillTreeCursor querySkillTreesSearch(String searchTerm) {
+        // "SELECT DISTINCT * FROM skill_trees
+        //  WHERE (name LIKE '% word%' OR name LIKE 'word%')
+        //    AND (name LIKE '% word2%' OR name LIKE 'word2%')
+        //  GROUP BY name"
+
+        QueryHelper qh = new QueryHelper();
+        qh.Distinct = true;
+        qh.Table = S.TABLE_SKILL_TREES;
+        qh.Columns = null;
+        qh.Selection = null;
+        qh.SelectionArgs = null;
+        qh.GroupBy = S.COLUMN_SKILL_TREES_NAME;
+        qh.Having = null;
+        qh.OrderBy = null;
+        qh.Limit = null;
+
+        modifyQueryForSearch(qh, S.COLUMN_SKILL_TREES_NAME, searchTerm);
 
         return new SkillTreeCursor(wrapHelper(qh));
     }

--- a/app/src/main/java/com/ghstudios/android/data/database/MultiObjectCursor.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/MultiObjectCursor.java
@@ -45,7 +45,7 @@ public class MultiObjectCursor extends CursorWrapper {
             super(cursor);
             this.handler = handler;
 
-            if (cursor.getColumnName(0) != "_id") {
+            if (!cursor.getColumnName(0).equals("_id")) {
                 throw new IllegalArgumentException("Invalid cursor: the first column must be called _id");
             }
         }

--- a/app/src/main/java/com/ghstudios/android/data/database/MultiObjectCursor.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/MultiObjectCursor.java
@@ -35,9 +35,19 @@ public class MultiObjectCursor extends CursorWrapper {
         private MultiObjectCursor parent;
         private Handler handler;
 
+        /**
+         * Creates a new IdentifyingCursorWrapper
+         * @param cursor
+         * @param handler
+         * @throws IllegalArgumentException if the cursor's first column is not _id
+         */
         public IdentifyingCursorWrapper(Cursor cursor, Handler handler) {
             super(cursor);
             this.handler = handler;
+
+            if (cursor.getColumnName(0) != "_id") {
+                throw new IllegalArgumentException("Invalid cursor: the first column must be called _id");
+            }
         }
 
         private void setOwner(MultiObjectCursor parent) {
@@ -67,11 +77,13 @@ public class MultiObjectCursor extends CursorWrapper {
         /**
          * A special version of add which takes a method name instead of a handler.
          * This version uses reflection to create the handler. This handler
-         * will invoke the given method on the cursor.
+         * will invoke the given method on the cursor. The cursor's first column must be _id
+         * so that the id lookup remains consistent (A requirement to use CursorAdapter).
          * @param cursor
          * @param methodName
          * @param <T>
-         * @throws NoSuchMethodException
+         * @throws NoSuchMethodException if the given cursor doesn't have the listed method
+         * @throws IllegalArgumentException if the cursor's first column is not _id
          */
         public <T extends Cursor> void add(T cursor, String methodName) throws NoSuchMethodException {
             final Method method = cursor.getClass().getMethod(methodName);

--- a/app/src/main/java/com/ghstudios/android/loader/UniversalSearchCursorLoader.java
+++ b/app/src/main/java/com/ghstudios/android/loader/UniversalSearchCursorLoader.java
@@ -25,6 +25,7 @@ public class UniversalSearchCursorLoader extends SQLiteCursorLoader {
             MultiObjectCursor.Builder builder = new MultiObjectCursor.Builder();
             builder.add(manager.queryMonstersSearch(searchTerm), "getMonster");
             builder.add(manager.queryQuestsSearch(searchTerm), "getQuest");
+            builder.add(manager.querySkillTreesSearch(searchTerm), "getSkillTree");
             builder.add(manager.queryItemSearch(searchTerm), "getItem");
 
             return builder.create();

--- a/app/src/main/java/com/ghstudios/android/ui/list/UniversalSearchFragment.java
+++ b/app/src/main/java/com/ghstudios/android/ui/list/UniversalSearchFragment.java
@@ -160,7 +160,12 @@ public class UniversalSearchFragment extends ListFragment implements
 
             @Override
             public String getType(Item obj) {
-                return obj.getType();
+                String type = obj.getType();
+                if (type == null || type.equals("")) {
+                    // todo: localize, but item types should be localized too
+                    type = "Item";
+                }
+                return type;
             }
 
             @Override

--- a/app/src/main/java/com/ghstudios/android/ui/list/UniversalSearchFragment.java
+++ b/app/src/main/java/com/ghstudios/android/ui/list/UniversalSearchFragment.java
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import com.ghstudios.android.data.classes.Item;
 import com.ghstudios.android.data.classes.Monster;
 import com.ghstudios.android.data.classes.Quest;
+import com.ghstudios.android.data.classes.SkillTree;
 import com.ghstudios.android.data.database.MultiObjectCursor;
 import com.ghstudios.android.loader.UniversalSearchCursorLoader;
 import com.ghstudios.android.mhgendatabase.R;
@@ -27,6 +28,7 @@ import com.ghstudios.android.ui.ClickListeners.MaterialClickListener;
 import com.ghstudios.android.ui.ClickListeners.MonsterClickListener;
 import com.ghstudios.android.ui.ClickListeners.PalicoWeaponClickListener;
 import com.ghstudios.android.ui.ClickListeners.QuestClickListener;
+import com.ghstudios.android.ui.ClickListeners.SkillClickListener;
 import com.ghstudios.android.ui.ClickListeners.WeaponClickListener;
 
 import java.io.IOException;
@@ -35,11 +37,33 @@ import java.util.HashMap;
 public class UniversalSearchFragment extends ListFragment implements
         LoaderManager.LoaderCallbacks<Cursor> {
 
-    private interface ResultHandler<T> {
-        String getImage(T obj);
-        String getName(T obj);
-        String getType(T obj);
-        View.OnClickListener createListener(T obj);
+    /**
+     * A simple handler class used to create mappings for the Universal Search results.
+     * Override EITHER getImagePath or getImageResource so that getImage() will handle the rest.
+     * @param <T>
+     */
+    private abstract class ResultHandler<T> {
+        public String getImagePath(T obj) { return null; }
+        public int getImageResource(T obj) { return -1; }
+        abstract String getName(T obj);
+        abstract String getType(T obj);
+        abstract View.OnClickListener createListener(T obj);
+
+        public Drawable getImage(T obj, Context ctx) {
+            try {
+                String imagePath = this.getImagePath(obj);
+                if (imagePath != null) {
+                    return Drawable.createFromStream(ctx.getAssets().open(imagePath), null);
+                } else {
+                    int resource = this.getImageResource(obj);
+                    return Drawable.createFromStream(ctx.getResources().openRawResource(resource), null);
+                }
+            } catch (IOException e) {
+                // should this throw instead of returning null?
+                e.printStackTrace();
+                return null;
+            }
+        }
     }
 
     private HashMap<Class, ResultHandler> mHandlers = new HashMap<>();
@@ -52,7 +76,7 @@ public class UniversalSearchFragment extends ListFragment implements
 
         mHandlers.put(Monster.class, new ResultHandler<Monster>() {
             @Override
-            public String getImage(Monster obj) {
+            public String getImagePath(Monster obj) {
                 return "icons_monster/" + obj.getFileLocation();
             }
 
@@ -74,9 +98,15 @@ public class UniversalSearchFragment extends ListFragment implements
 
         mHandlers.put(Quest.class, new ResultHandler<Quest>() {
             @Override
-            public String getImage(Quest obj) {
-                // todo: Change color if capture/slay (requires db + more icons)
-                return "icons_items/Quest-Icon-White.png";
+            public int getImageResource(Quest q) {
+                if(q.getHunterType() == 1)
+                    return R.drawable.quest_cat;
+                else if(q.getGoalType() == Quest.QUEST_GOAL_DELIVER)
+                    return R.drawable.quest_icon_green;
+                else if(q.getGoalType() == Quest.QUEST_GOAL_CAPTURE)
+                    return R.drawable.quest_icon_grey;
+                else
+                    return R.drawable.quest_icon_red;
             }
 
             @Override
@@ -95,9 +125,31 @@ public class UniversalSearchFragment extends ListFragment implements
             }
         });
 
+        mHandlers.put(SkillTree.class, new ResultHandler<SkillTree>() {
+            @Override
+            public String getImagePath(SkillTree skill) {
+                return "icons_items/Bomb-White.png";
+            }
+
+            @Override
+            public String getName(SkillTree obj)  {
+                return obj.getName();
+            }
+
+            @Override
+            public String getType(SkillTree obj) {
+                return "Skill Tree";
+            }
+
+            @Override
+            public View.OnClickListener createListener(SkillTree obj) {
+                return new SkillClickListener(getActivity(), obj.getId());
+            }
+        });
+
         mHandlers.put(Item.class, new ResultHandler<Item>() {
             @Override
-            public String getImage(Item item) {
+            public String getImagePath(Item item) {
                 return item.getItemImage();
             }
 
@@ -121,9 +173,9 @@ public class UniversalSearchFragment extends ListFragment implements
                     case "Decoration":
                         return new DecorationClickListener(getActivity(), obj.getId());
                     case "Materials":
-                        return new MaterialClickListener(getActivity(),obj.getId());
+                        return new MaterialClickListener(getActivity(), obj.getId());
                     case "Palico Weapon":
-                        return new PalicoWeaponClickListener(getActivity(),obj.getId());
+                        return new PalicoWeaponClickListener(getActivity(), obj.getId());
                     default:
                         return new ItemClickListener(getActivity(), obj.getId());
                 }
@@ -206,20 +258,8 @@ public class UniversalSearchFragment extends ListFragment implements
             TextView nameView = (TextView) view.findViewById(R.id.result_name);
             TextView typeView = (TextView) view.findViewById(R.id.result_type);
 
-            String imagePath = handler.getImage(result);
-            if (imagePath != null) {
-                Drawable itemImage = null;
-
-                try {
-                    itemImage = Drawable.createFromStream(
-                            context.getAssets().open(imagePath), null);
-                } catch (IOException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-
-                imageView.setImageDrawable(itemImage);
-            }
+            Drawable image = handler.getImage(result, context);
+            imageView.setImageDrawable(image);
 
             nameView.setText(handler.getName(result));
             typeView.setText(handler.getType(result));


### PR DESCRIPTION
Some quick changes to support skill trees. The bug that had prevented it was the CursorAdapter requiring _id to always be on the same column index, and skill trees returned few columns and led to out of bounds. Slipped in Quest Icon colors and items defaulting to type "Item" while I was at it.

![image](https://cloud.githubusercontent.com/assets/1286721/17273487/fce687d2-5683-11e6-99f5-f3154a970bfe.png)

![image](https://cloud.githubusercontent.com/assets/1286721/17273492/30d68f38-5684-11e6-8f3a-1a8c944c2963.png)
