### PR TITLE
Item Detail Redesign. Tab layout fixes, Monster Summary fixes, split screen support on N.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:resizeableActivity="true">
 
         <!-- UNIVERSAL SEARCH SECTION -->
         <activity

--- a/app/src/main/java/com/ghstudios/android/ui/detail/ItemDetailActivity.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/ItemDetailActivity.java
@@ -32,7 +32,6 @@ public class ItemDetailActivity extends GenericTabActivity {
         viewPager = (ViewPager) findViewById(R.id.pager);
         mAdapter = new ItemDetailPagerAdapter(getSupportFragmentManager(), id);
         viewPager.setAdapter(mAdapter);
-        mSlidingTabLayout.setDistributeEvenly(false);
         mSlidingTabLayout.setViewPager(viewPager);
     }
 

--- a/app/src/main/java/com/ghstudios/android/ui/detail/LocationDetailActivity.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/LocationDetailActivity.java
@@ -31,7 +31,6 @@ public class LocationDetailActivity extends GenericTabActivity {
         viewPager = (ViewPager) findViewById(R.id.pager);
         mAdapter = new LocationDetailPagerAdapter(getSupportFragmentManager(), id);
         viewPager.setAdapter(mAdapter);
-        mSlidingTabLayout.setDistributeEvenly(false);   //JOE:Too many tabs
         mSlidingTabLayout.setViewPager(viewPager);
     }
 

--- a/app/src/main/java/com/ghstudios/android/ui/detail/MonsterSummaryFragment.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/MonsterSummaryFragment.java
@@ -50,7 +50,7 @@ public class MonsterSummaryFragment extends Fragment {
 	private FlowLayout mWeaknessModData, mTrapModData, mBombModData;
 	private LinearLayout mWeaknessMod, mTrapMod, mBombMod;
 	private View mWeaknessModDiv, mTrapModDiv, mBombModDiv;
-	private TextView mWeaknessModText, mTrapModText, mBombModText, mMovesData,mModStateText;
+	private TextView mWeaknessModText, mTrapModText, mBombModText, mModStateText;
 	private LinearLayout mAilments,mModStateHeader;
 
 	// Need to add dividers
@@ -102,7 +102,6 @@ public class MonsterSummaryFragment extends Fragment {
 		mTrapData = (FlowLayout) view.findViewById(R.id.trap_data);
 		mBombData = (FlowLayout) view.findViewById(R.id.bomb_data);
 		mAilments = (LinearLayout) view.findViewById(R.id.ailments_data);
-		mMovesData = (TextView) view.findViewById(R.id.moves_data);
 
 		// Mods if monster has a secondary state
 		// Sections
@@ -315,10 +314,6 @@ public class MonsterSummaryFragment extends Fragment {
 			if(mWeakness.getDungbomb() != 0)
 				addIcon(mBombModData, getResources().getString(R.string.image_location_dung_bomb), null);
 		}
-
-
-		// Signature Moves section
-		mMovesData.setText(mMonster.getSignatureMove());
 
 	}
 

--- a/app/src/main/java/com/ghstudios/android/ui/detail/WeaponDetailActivity.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/WeaponDetailActivity.java
@@ -55,11 +55,6 @@ public class WeaponDetailActivity extends GenericTabActivity {
         mAdapter = new WeaponDetailPagerAdapter(getSupportFragmentManager(), getApplicationContext(), id,wtype);
         viewPager.setAdapter(mAdapter);
 
-        //If we have a lot of tabs
-        if(mAdapter.getCount()>3)
-            mSlidingTabLayout.setDistributeEvenly(false);
-
-
         mSlidingTabLayout.setViewPager(viewPager);
     }
 

--- a/app/src/main/java/com/ghstudios/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/ghstudios/android/ui/general/GenericActionBarActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
@@ -34,15 +35,17 @@ import android.widget.TextView;
 
 import com.ghstudios.android.mhgendatabase.R;
 import com.ghstudios.android.ui.dialog.AboutDialogFragment;
-import com.ghstudios.android.ui.list.*;
+import com.ghstudios.android.ui.list.ASBSetListActivity;
 import com.ghstudios.android.ui.list.ArmorListActivity;
 import com.ghstudios.android.ui.list.CombiningListActivity;
 import com.ghstudios.android.ui.list.DecorationListActivity;
 import com.ghstudios.android.ui.list.ItemListActivity;
 import com.ghstudios.android.ui.list.LocationListActivity;
 import com.ghstudios.android.ui.list.MonsterListActivity;
+import com.ghstudios.android.ui.list.PalicoActivity;
 import com.ghstudios.android.ui.list.QuestListActivity;
 import com.ghstudios.android.ui.list.SkillTreeListActivity;
+import com.ghstudios.android.ui.list.UniversalSearchActivity;
 import com.ghstudios.android.ui.list.WeaponSelectionListActivity;
 import com.ghstudios.android.ui.list.WishlistListActivity;
 import com.ghstudios.android.ui.list.adapter.MenuSection;
@@ -120,6 +123,12 @@ public abstract class GenericActionBarActivity extends AppCompatActivity {
         //mDrawerLayout.setStatusBarBackgroundColor(#000000); // I think this is used to have the drawer behind the status bar
         // Populate navigation drawer
         mDrawerList = (ListView) findViewById(R.id.navList);
+
+        // Allow the header image to scroll away. Only supported on Lollipop+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+            mDrawerList.setNestedScrollingEnabled(true);
+        }
+
         addDrawerItems();
         mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override

--- a/app/src/main/java/com/ghstudios/android/ui/general/GenericTabActivity.java
+++ b/app/src/main/java/com/ghstudios/android/ui/general/GenericTabActivity.java
@@ -35,13 +35,15 @@ public abstract class GenericTabActivity extends GenericActionBarActivity {
         mSlidingTabLayout = (SlidingTabLayout) findViewById(R.id.sliding_tabs);
         //mSlidingTabLayout.setCustomTabView(R.layout.sliding_tab_layout, R.id.text1);
 
+        // Distribute evenly if we have less than 4 tabs
+        mSlidingTabLayout.setDistributeEvenlyLimit(4);
+
         Point size = new Point();
         getWindowManager().getDefaultDisplay().getSize(size);
 
         int width = size.x;
 
         mSlidingTabLayout.setMinimumWidth(width);
-        mSlidingTabLayout.setDistributeEvenly(true);
 
 
         setTitle(R.string.app_name);

--- a/app/src/main/java/com/ghstudios/android/ui/general/SlidingTabLayout.java
+++ b/app/src/main/java/com/ghstudios/android/ui/general/SlidingTabLayout.java
@@ -55,7 +55,7 @@ public class SlidingTabLayout extends HorizontalScrollView {
 
     private int mTabViewLayoutId;
     private int mTabViewTextViewId;
-    private boolean mDistributeEvenly;
+    private int mDistributeEvenlyLimit;
 
     private ViewPager mViewPager;
     private ViewPager.OnPageChangeListener mViewPagerPageChangeListener;
@@ -95,8 +95,13 @@ public class SlidingTabLayout extends HorizontalScrollView {
         mTabStrip.setCustomTabColorizer(tabColorizer);
     }
 
-    public void setDistributeEvenly(boolean distributeEvenly) {
-        mDistributeEvenly = distributeEvenly;
+    /**
+     * Tabs will be evenly distributed unless number of tabs is greater than this limit.
+     * Higher limits should only be used in landscape mode or tablets.
+     * @param limit Setting this to 0 will lay tabs left to right
+     */
+    public void setDistributeEvenlyLimit(int limit){
+        mDistributeEvenlyLimit = limit;
     }
 
     /**
@@ -191,7 +196,8 @@ public class SlidingTabLayout extends HorizontalScrollView {
                 tabTitleView = (TextView) tabView;
             }
 
-            if (mDistributeEvenly) {
+            // If number of tabs is under the limit, distribute them evenly across the screen.
+            if(adapter.getCount() <= mDistributeEvenlyLimit) {
                 LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams) tabView.getLayoutParams();
                 lp.width = 0;
                 lp.weight = 1;

--- a/app/src/main/res/layout-sw600dp/drawer_list.xml
+++ b/app/src/main/res/layout-sw600dp/drawer_list.xml
@@ -1,18 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="300dp"
-    android:orientation="vertical"
-    android:layout_gravity="left|start">
-    <ImageView
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_gravity="left|start"
+    android:fillViewport="true"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:layout_gravity="center"
-        android:clickable="true"
-        android:src="@drawable/drawer_img"
-        android:contentDescription="@string/logo_description"/>
+        android:fitsSystemWindows="true">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/toolbar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            app:titleEnabled="false"
+            app:contentScrim="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:layout_gravity="center"
+                android:src="@drawable/drawer_img"
+                android:contentDescription="@string/logo_description"/>
+        </android.support.design.widget.CollapsingToolbarLayout>
+    </android.support.design.widget.AppBarLayout>
 
     <ListView
         android:id="@+id/navList"
@@ -23,7 +41,9 @@
         android:dividerHeight="1dp"
         android:background="@color/list_background"
         android:fitsSystemWindows="true"
-        tools:listitem="@layout/drawer_list_item"/>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/drawer_list_item"
+        />
 
-    </LinearLayout>
+</android.support.design.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/drawer_list.xml
+++ b/app/src/main/res/layout/drawer_list.xml
@@ -1,19 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginRight="56dp"
-    android:orientation="vertical"
-    android:layout_gravity="left|start">
-    <ImageView
+    android:layout_gravity="left|start"
+    android:fillViewport="true"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:layout_gravity="center"
-        android:clickable="true"
-        android:src="@drawable/drawer_img"
-        android:contentDescription="@string/logo_description"/>
+        android:fitsSystemWindows="true">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/toolbar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            app:titleEnabled="false"
+            app:contentScrim="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:layout_gravity="center"
+                android:src="@drawable/drawer_img"
+                android:contentDescription="@string/logo_description"/>
+        </android.support.design.widget.CollapsingToolbarLayout>
+    </android.support.design.widget.AppBarLayout>
 
     <ListView
         android:id="@+id/navList"
@@ -24,7 +42,9 @@
         android:dividerHeight="1dp"
         android:background="@color/list_background"
         android:fitsSystemWindows="true"
-        tools:listitem="@layout/drawer_list_item"/>
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/drawer_list_item"
+        />
 
-    </LinearLayout>
+</android.support.design.widget.CoordinatorLayout>
 

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -1,127 +1,131 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
-
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:padding="10dp" >
+        android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/detail_item_image"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_marginRight="10dp"
-            android:contentDescription="@string/monster_image" >
-        </ImageView>
-
-        <TextView
-            android:id="@+id/detail_item_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:text="@string/placeholder_unknown"
-            android:paddingLeft="10dp"
-            android:textStyle="bold"
-            android:textSize="20dp"
-            android:textColor="@color/text_color">
-        </TextView>
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:baselineAligned="false"
-        android:orientation="horizontal" >
-
+        <RelativeLayout
+            style="@style/title_bar">
+            <TextView
+                android:id="@+id/detail_item_label"
+                tools:text="Barrel Bomb L+"
+                style="@style/title_bar_text" />
+        </RelativeLayout>
         <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight=".3"
-            android:orientation="vertical"
-            android:paddingLeft="10dp" >
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="12dp"
+            android:paddingRight="12dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:layout_gravity="center_horizontal">
+            <ImageView
+                android:id="@+id/detail_item_image"
+                android:layout_width="50dp"
+                android:layout_height="match_parent"
+                android:layout_marginRight="16dp"
+                android:contentDescription="@string/monster_image"
+                tools:src="@drawable/dual_blades1">
+            </ImageView>
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+                <TextView
+                    android:id="@+id/buy"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    tools:text="800z"
+                    style="@style/detail_header_text"/>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:text="@string/item_buy"
+                    style="@style/detail_subheader_text"/>
+            </LinearLayout>
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+                <TextView
+                    android:id="@+id/sell"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    tools:text="80z"
+                    style="@style/detail_header_text"/>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:text="@string/item_sell"
+                    style="@style/detail_subheader_text"/>
+            </LinearLayout>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Rare:"
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Max:"
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Buy:"
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Sell:"
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text=""
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Description:"
-                android:textColor="@color/text_color" />
         </LinearLayout>
 
         <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight=".7"
-            android:orientation="vertical" >
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            android:layout_marginBottom="10dp"
+            android:background="@color/text_color_secondary"/>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/text_small_secondary"
+                android:layout_marginBottom="4dp"
+                android:text="@string/item_rarity"/>
             <TextView
                 android:id="@+id/rare"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/text_color" />
-
+                style="@style/detail_value_text"
+                tools:text="2"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/text_small_secondary"
+                android:layout_marginBottom="4dp"
+                android:text="@string/item_max"/>
             <TextView
                 android:id="@+id/max"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:id="@+id/buy"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/text_color" />
-
-            <TextView
-                android:id="@+id/sell"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/text_color" />
-
+                style="@style/detail_value_text"
+                tools:text="2"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/text_color" />
-
+                style="@style/text_small_secondary"
+                android:layout_marginBottom="4dp"
+                android:text="@string/item_description"/>
             <TextView
                 android:id="@+id/description"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/text_color" />
+                style="@style/text_medium"
+                android:textColor="@color/weapon_property_color"
+                android:layout_marginBottom="8dp"
+                android:text="Upgraded Large Barrlel Bomb. Effective against large monsters."/>
         </LinearLayout>
-    </LinearLayout>
 
-</LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_monster_summary.xml
+++ b/app/src/main/res/layout/fragment_monster_summary.xml
@@ -283,7 +283,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
-                android:animateLayoutChanges="true"
                 android:orientation="vertical"
                 android:layout_below="@+id/ailments_label">
 
@@ -306,40 +305,6 @@
                     android:visibility="gone"
                     tools:visibility="visible"/>
             </LinearLayout>
-
-        </RelativeLayout>
-
-        <View
-            android:background="@color/divider_color"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"/>
-
-        <!-- Signature Moves -->
-        <RelativeLayout
-            android:id="@+id/moves"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            style="@style/list_item"
-            android:minHeight="48dp">
-
-            <TextView
-                android:id="@+id/moves_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                style="@style/text_medium"
-                android:text="Signature Moves"/>
-
-            <TextView
-                android:id="@+id/moves_data"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="16dp"
-                android:ellipsize="none"
-                android:maxLines="100"
-                android:scrollHorizontally="false"
-                android:layout_below="@id/moves_label"
-                android:animateLayoutChanges="true"
-                tools:text="Mandible attack, Web shot, Abdomen sting" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/fragment_weapon_blade_detail.xml
+++ b/app/src/main/res/layout/fragment_weapon_blade_detail.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -7,7 +8,7 @@
         style="@style/title_bar">
         <TextView
             android:id="@+id/detail_title_bar_text"
-            android:text="Title Bar Text"
+            tools:text="Title Bar Text"
             style="@style/title_bar_text" />
     </RelativeLayout>
     <ScrollView
@@ -33,17 +34,16 @@
             <TextView
                 android:id="@+id/detail_weapon_attack"
                 android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="180"
+                tools:text="180"
                 style="@style/detail_header_text"/>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="Attack"
+                tools:text="Attack"
                 style="@style/detail_subheader_text"/>
         </LinearLayout>
         <LinearLayout
@@ -55,17 +55,16 @@
             <TextView
                 android:id="@+id/detail_weapon_element"
                 android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="28"
+                tools:text="28"
                 style="@style/detail_header_text"/>
             <TextView
                 android:id="@+id/detail_weapon_element_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="Fire"
+                tools:text="Fire"
                 style="@style/detail_subheader_text"/>
         </LinearLayout>
         <LinearLayout
@@ -79,14 +78,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="18"
+                tools:text="18"
                 style="@style/detail_header_text"/>
             <TextView
                 android:id="@+id/detail_weapon_element_2_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="Poison"
+                tools:text="Poison"
                 style="@style/detail_subheader_text"/>
         </LinearLayout>
         <LinearLayout
@@ -99,14 +98,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="5%"
+                tools:text="5%"
                 style="@style/detail_header_text"/>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="Affinity"
+                tools:text="Affinity"
                 style="@style/detail_subheader_text"/>
         </LinearLayout>
         <LinearLayout
@@ -117,17 +116,16 @@
             <TextView
                 android:id="@+id/detail_weapon_slot"
                 android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:text="---"
+                tools:text="---"
                 style="@style/detail_header_text"/>
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal|bottom"
-                android:text="Slots"
+                tools:text="Slots"
                 style="@style/detail_subheader_text"/>
         </LinearLayout>
     </LinearLayout>
@@ -151,7 +149,7 @@
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Sharpness"/>
+            tools:text="Sharpness"/>
         <com.ghstudios.android.ui.general.DrawSharpness
             android:id="@+id/detail_weapon_blade_sharpness"
             android:layout_width="160dp"
@@ -163,7 +161,7 @@
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Notes"/>
+            tools:text="Notes"/>
         <LinearLayout
             android:id="@+id/detail_weapon_note_container"
             android:layout_width="wrap_content"
@@ -188,72 +186,72 @@
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Phial Type"/>
+            tools:text="Phial Type"/>
         <TextView
             android:id="@+id/detail_weapon_blade_special_value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/detail_value_text"
-            android:text="Element"/>
+            tools:text="Element"/>
         <TextView
             android:id="@+id/detail_weapon_defense_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Defense"/>
+            tools:text="Defense"/>
         <TextView
             android:id="@+id/detail_weapon_defense"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/detail_value_text"
-            android:text="10"/>
+            tools:text="10"/>
         <!--Upgrade Cost-->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Upgrade Cost"/>
+            tools:text="Upgrade Cost"/>
         <TextView
             android:id="@+id/detail_weapon_upgrade"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/detail_value_text"
-            android:text="48000z"/>
+            tools:text="48000z"/>
         <!--Creation Cost-->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Creation Cost"/>
+            tools:text="Creation Cost"/>
         <TextView
             android:id="@+id/detail_weapon_creation"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/detail_value_text"
-            android:text="-"/>
-        <!--Creation Cost-->
+            tools:text="-"/>
+        <!--Rarity-->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Rarity"/>
+            tools:text="Rarity"/>
         <TextView
             android:id="@+id/detail_weapon_rarity"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/detail_value_text"
-            android:text="5"/>
-        <!--Creation Cost-->
+            tools:text="5"/>
+        <!--Description-->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/text_small_secondary"
             android:layout_marginBottom="4dp"
-            android:text="Description"/>
+            tools:text="Description"/>
         <TextView
             android:id="@+id/detail_weapon_description"
             android:layout_width="wrap_content"
@@ -261,7 +259,7 @@
             style="@style/text_medium"
             android:textColor="@color/weapon_property_color"
             android:layout_marginBottom="8dp"
-            android:text="5"/>
+            tools:text="5"/>
     </LinearLayout>
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/sliding_tab_layout.xml
+++ b/app/src/main/res/layout/sliding_tab_layout.xml
@@ -4,12 +4,11 @@
     android:id="@android:id/text1"
     android:background="?android:selectableItemBackground"
     android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:paddingLeft="12dp"
     android:paddingRight="12dp"
-    android:layout_height="48dp"
     android:textSize="12sp"
     android:gravity="center"
-    android:singleLine="true"
     android:maxLines="1"
     android:textColor="@color/text_primary_color"
     android:textAllCaps="true" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,13 @@
     Unicode Dash \u2015
     -->
 
+    <!-- Item details -->
+    <string name="item_rarity">Rarity</string>
+    <string name="item_max">Max</string>
+    <string name="item_buy">Buy</string>
+    <string name="item_sell">Sell</string>
+    <string name="item_description">Description</string>
+
     <!-- Wishlist stuff -->
 
     <string name="wishlist_text_total">Total cost</string>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Tue Sep 13 14:11:03 EDT 2016
+#Fri Oct 14 11:51:52 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Item Details

Item details screen has been reformatted to match the styling used in the Weapon and Palico Weapon details screens. This same redesign still needs to happen for the Quest Details screen.

![Item Details Screen](http://i.imgur.com/PUOuYJE.jpg)
## Tabs

Tabs are now set to DistributeEvenly when there are 4 tabs or less. This should fix some issues we had with line wrapping.
## Monster Summary

Special Moves section is removed from Monster Summary. The Ailments section no longer animates in oddly.
## Split Screen Support

Declared split screen support in the manifest. The only modification made to accommodate was making the drawer header scroll away. To better support split screen we would need to have every action bar/tab selector hide upon scrolling.
