### PR TITLE
Drawer scrolling fix for devices < API 21 Lollipop.

### DIFF
--- a/app/src/main/res/layout-sw600dp-v21/drawer_list.xml
+++ b/app/src/main/res/layout-sw600dp-v21/drawer_list.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="300dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_gravity="left|start"
+    android:fillViewport="true"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/toolbar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            app:titleEnabled="false"
+            app:contentScrim="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:layout_gravity="center"
+                android:src="@drawable/drawer_img"
+                android:contentDescription="@string/logo_description"/>
+        </android.support.design.widget.CollapsingToolbarLayout>
+    </android.support.design.widget.AppBarLayout>
+
+    <ListView
+        android:id="@+id/navList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:choiceMode="singleChoice"
+        android:divider="@color/navigationDividerColor"
+        android:dividerHeight="1dp"
+        android:background="@color/list_background"
+        android:fitsSystemWindows="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/drawer_list_item"
+        />
+
+</android.support.design.widget.CoordinatorLayout>
+

--- a/app/src/main/res/layout-sw600dp/drawer_list.xml
+++ b/app/src/main/res/layout-sw600dp/drawer_list.xml
@@ -1,36 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="300dp"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_gravity="left|start"
-    android:fillViewport="true"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/app_bar"
+    android:orientation="vertical"
+    android:layout_gravity="left|start">
+    <ImageView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
-
-        <android.support.design.widget.CollapsingToolbarLayout
-            android:id="@+id/toolbar_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
-            app:titleEnabled="false"
-            app:contentScrim="?attr/colorPrimary"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed">
-
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:adjustViewBounds="true"
-                android:layout_gravity="center"
-                android:src="@drawable/drawer_img"
-                android:contentDescription="@string/logo_description"/>
-        </android.support.design.widget.CollapsingToolbarLayout>
-    </android.support.design.widget.AppBarLayout>
+        android:adjustViewBounds="true"
+        android:layout_gravity="center"
+        android:clickable="true"
+        android:src="@drawable/drawer_img"
+        android:contentDescription="@string/logo_description"/>
 
     <ListView
         android:id="@+id/navList"
@@ -41,9 +23,7 @@
         android:dividerHeight="1dp"
         android:background="@color/list_background"
         android:fitsSystemWindows="true"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:listitem="@layout/drawer_list_item"
-        />
+        tools:listitem="@layout/drawer_list_item"/>
 
-</android.support.design.widget.CoordinatorLayout>
+    </LinearLayout>
 

--- a/app/src/main/res/layout-v21/drawer_list.xml
+++ b/app/src/main/res/layout-v21/drawer_list.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginRight="56dp"
+    android:layout_gravity="left|start"
+    android:fillViewport="true"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/toolbar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true"
+            app:titleEnabled="false"
+            app:contentScrim="?attr/colorPrimary"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <ImageView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:layout_gravity="center"
+                android:src="@drawable/drawer_img"
+                android:contentDescription="@string/logo_description"/>
+        </android.support.design.widget.CollapsingToolbarLayout>
+    </android.support.design.widget.AppBarLayout>
+
+    <ListView
+        android:id="@+id/navList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:choiceMode="singleChoice"
+        android:divider="@color/navigationDividerColor"
+        android:dividerHeight="1dp"
+        android:background="@color/list_background"
+        android:fitsSystemWindows="true"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/drawer_list_item"
+        />
+
+</android.support.design.widget.CoordinatorLayout>
+

--- a/app/src/main/res/layout/drawer_list.xml
+++ b/app/src/main/res/layout/drawer_list.xml
@@ -1,37 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginRight="56dp"
-    android:layout_gravity="left|start"
-    android:fillViewport="true"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/app_bar"
+    android:orientation="vertical"
+    android:layout_gravity="left|start">
+    <ImageView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
-
-        <android.support.design.widget.CollapsingToolbarLayout
-            android:id="@+id/toolbar_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
-            app:titleEnabled="false"
-            app:contentScrim="?attr/colorPrimary"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed">
-
-            <ImageView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:adjustViewBounds="true"
-                android:layout_gravity="center"
-                android:src="@drawable/drawer_img"
-                android:contentDescription="@string/logo_description"/>
-        </android.support.design.widget.CollapsingToolbarLayout>
-    </android.support.design.widget.AppBarLayout>
+        android:adjustViewBounds="true"
+        android:layout_gravity="center"
+        android:clickable="true"
+        android:src="@drawable/drawer_img"
+        android:contentDescription="@string/logo_description"/>
 
     <ListView
         android:id="@+id/navList"
@@ -42,9 +24,7 @@
         android:dividerHeight="1dp"
         android:background="@color/list_background"
         android:fitsSystemWindows="true"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:listitem="@layout/drawer_list_item"
-        />
+        tools:listitem="@layout/drawer_list_item"/>
 
-</android.support.design.widget.CoordinatorLayout>
+    </LinearLayout>
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 


### PR DESCRIPTION
Made drawers with scrollable headers only visible on API 21 and above… (lollipop) as nav bar scrolling was broken for <21.

Updated to gradle 2.2.2.
