### PR TITLE
[WIP] Monster Equipment Tab

### DIFF
--- a/app/src/main/java/com/ghstudios/android/data/classes/MonsterEquipment.java
+++ b/app/src/main/java/com/ghstudios/android/data/classes/MonsterEquipment.java
@@ -1,0 +1,26 @@
+package com.ghstudios.android.data.classes;
+
+/**
+ * A view of an item derived by crafting a particular monster drop
+ * Created by Carlos on 1/24/2017.
+ */
+public class MonsterEquipment {
+    private Item item;
+    private String rank;        // Quest rank
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public String getRank() {
+        return rank;
+    }
+
+    public void setRank(String rank) {
+        this.rank = rank;
+    }
+}

--- a/app/src/main/java/com/ghstudios/android/data/database/DataManager.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/DataManager.java
@@ -707,6 +707,12 @@ public class DataManager {
 		return weaknesses;
 	}
 
+/********************************* MONSTER EQUIPMENT QUERIES ******************************************/
+
+	public ItemCursor queryMonsterEquipment(long monsterId) {
+		return mHelper.queryMonsterEquipment(monsterId);
+	}
+
 /********************************* QUEST QUERIES ******************************************/	
 
 	/* Get a Cursor that has a list of all Quests */

--- a/app/src/main/java/com/ghstudios/android/data/database/DataManager.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/DataManager.java
@@ -709,7 +709,7 @@ public class DataManager {
 
 /********************************* MONSTER EQUIPMENT QUERIES ******************************************/
 
-	public ItemCursor queryMonsterEquipment(long monsterId) {
+	public MonsterEquipmentCursor queryMonsterEquipment(long monsterId) {
 		return mHelper.queryMonsterEquipment(monsterId);
 	}
 

--- a/app/src/main/java/com/ghstudios/android/data/database/MonsterEquipmentCursor.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/MonsterEquipmentCursor.java
@@ -1,0 +1,34 @@
+package com.ghstudios.android.data.database;
+
+import android.database.Cursor;
+import android.database.CursorWrapper;
+
+import com.ghstudios.android.data.classes.Item;
+import com.ghstudios.android.data.classes.MonsterEquipment;
+
+/**
+ * Created by Carlos on 1/24/2017.
+ */
+
+public class MonsterEquipmentCursor extends CursorWrapper {
+    public MonsterEquipmentCursor(Cursor c) {
+        super(c);
+    }
+
+    public MonsterEquipment getMonsterItem() {
+        MonsterEquipment monItem = new MonsterEquipment();
+
+        // todo: this type of logic is often copy pasted and should be centralized
+        Item item = new Item();
+        item.setId(getLong(getColumnIndex(S.COLUMN_ITEMS_ID)));
+        item.setName(getString(getColumnIndex(S.COLUMN_ITEMS_NAME)));
+        item.setType(getString(getColumnIndex(S.COLUMN_ITEMS_TYPE)));
+        item.setSubType(getString(getColumnIndex(S.COLUMN_ITEMS_SUB_TYPE)));
+        item.setRarity(getInt(getColumnIndex(S.COLUMN_ITEMS_RARITY)));
+        item.setFileLocation(getString(getColumnIndex(S.COLUMN_ITEMS_ICON_NAME)));
+
+        monItem.setItem(item);
+        monItem.setRank(getString(getColumnIndex(S.COLUMN_HUNTING_REWARDS_RANK)));
+        return monItem;
+    }
+}

--- a/app/src/main/java/com/ghstudios/android/data/database/MonsterHunterDatabaseHelper.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/MonsterHunterDatabaseHelper.java
@@ -564,8 +564,8 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
      * Note: This fails if there is already arguments on the query.
      * TODO: support arguments already existing by expanding the array and adding "AND"
      * @param qh
-     * @param columnName
-     * @param searchTerm
+     * @param columnName The column name to search on (ie: name)
+     * @param searchTerm The value being searched (injected as a parameter)
      */
     private void modifyQueryForSearch(QueryHelper qh, String columnName, String searchTerm) {
         // WHERE (name LIKE '% word1%' OR name LIKE 'word1%')
@@ -2301,6 +2301,41 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
         qh.Limit = null;
 
         return new MonsterWeaknessCursor(wrapHelper(qh));
+    }
+
+    /********************************* MONSTER EQUIPMENT QUERIES ******************************************/
+
+    public ItemCursor queryMonsterEquipment(long monsterId) {
+        QueryHelper qh = new QueryHelper();
+        qh.Distinct = true;
+        qh.Table = S.TABLE_ITEMS;
+        qh.Columns = new String[] { "i.*" };
+        qh.Selection = "r." + S.COLUMN_HUNTING_REWARDS_MONSTER_ID + "= ?";
+        qh.SelectionArgs = new String[]{String.valueOf(monsterId)};
+        qh.OrderBy = "i." + S.COLUMN_ITEMS_NAME;
+
+        return new ItemCursor(wrapJoinHelper(builderMonsterEquipment(), qh));
+    }
+
+    private SQLiteQueryBuilder builderMonsterEquipment()
+    {
+//        SELECT i.*
+//        FROM items i
+//        JOIN components c
+//        ON c.created_item_id = i._id
+//        JOIN hunting_rewards r
+//        ON r.item_id = c.component_item_id
+//        WHERE r.monster_id = :monset_id;
+
+
+        SQLiteQueryBuilder QB = new SQLiteQueryBuilder();
+        QB.setDistinct(true);
+        QB.setTables(
+                "items i " +
+                "JOIN components c ON c.created_item_id = i._id " +
+                "JOIN hunting_rewards r ON r.item_id = c.component_item_id");
+
+        return QB;
     }
 
     /**

--- a/app/src/main/java/com/ghstudios/android/data/database/S.java
+++ b/app/src/main/java/com/ghstudios/android/data/database/S.java
@@ -105,7 +105,7 @@ public class S {
 	static final String COLUMN_HUNTING_REWARDS_ITEM_ID = "item_id";
 	public static final String COLUMN_HUNTING_REWARDS_CONDITION = "condition";
 	static final String COLUMN_HUNTING_REWARDS_MONSTER_ID = "monster_id";
-	static final String COLUMN_HUNTING_REWARDS_RANK = "rank";
+	public static final String COLUMN_HUNTING_REWARDS_RANK = "rank";
 	static final String COLUMN_HUNTING_REWARDS_STACK_SIZE = "stack_size";
 	static final String COLUMN_HUNTING_REWARDS_PERCENTAGE = "percentage";
 	

--- a/app/src/main/java/com/ghstudios/android/loader/MonsterEquipmentListCursorLoader.java
+++ b/app/src/main/java/com/ghstudios/android/loader/MonsterEquipmentListCursorLoader.java
@@ -1,0 +1,24 @@
+package com.ghstudios.android.loader;
+
+import android.content.Context;
+import android.database.Cursor;
+
+import com.ghstudios.android.data.database.DataManager;
+
+/**
+ * Created by Carlos on 1/22/2017.
+ */
+public class MonsterEquipmentListCursorLoader extends SQLiteCursorLoader {
+    private long monsterId;
+
+    public MonsterEquipmentListCursorLoader(Context context, long monsterId) {
+        super(context);
+        this.monsterId = monsterId;
+    }
+
+    @Override
+    public Cursor loadCursor() {
+        // Query the specific armor
+        return DataManager.get(getContext()).queryMonsterEquipment(monsterId);
+    }
+}

--- a/app/src/main/java/com/ghstudios/android/ui/adapter/MonsterDetailPagerAdapter.java
+++ b/app/src/main/java/com/ghstudios/android/ui/adapter/MonsterDetailPagerAdapter.java
@@ -6,6 +6,7 @@ import android.support.v4.app.FragmentPagerAdapter;
 
 import com.ghstudios.android.loader.HuntingRewardListCursorLoader;
 import com.ghstudios.android.ui.detail.MonsterDamageFragment;
+import com.ghstudios.android.ui.detail.MonsterEquipmentFragment;
 import com.ghstudios.android.ui.detail.MonsterHabitatFragment;
 import com.ghstudios.android.ui.detail.MonsterQuestFragment;
 import com.ghstudios.android.ui.detail.MonsterRewardFragment;
@@ -30,6 +31,7 @@ public class MonsterDetailPagerAdapter extends FragmentPagerAdapter {
 		tabs.add("Low-Rank");
 		tabs.add("High-Rank");
 		//tabs.add("G-Rank");	//No G Rank in MHGen...
+		tabs.add("Equipment");
 		tabs.add("Quest");
 	}
 
@@ -62,6 +64,8 @@ public class MonsterDetailPagerAdapter extends FragmentPagerAdapter {
 			return MonsterRewardFragment.newInstance(monsterId, HuntingRewardListCursorLoader.RANK_HR);
 		else if(title.equals("G-Rank"))
 			return MonsterRewardFragment.newInstance(monsterId, HuntingRewardListCursorLoader.RANK_G);
+		else if(title.equals("Equipment"))
+			return MonsterEquipmentFragment.newInstance(monsterId);
 		else if(title.equals("Quest"))
 			return MonsterQuestFragment.newInstance(monsterId);
 		else return null;

--- a/app/src/main/java/com/ghstudios/android/ui/detail/MonsterEquipmentFragment.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/MonsterEquipmentFragment.java
@@ -17,7 +17,10 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.ghstudios.android.data.classes.Item;
+import com.ghstudios.android.data.classes.MonsterEquipment;
 import com.ghstudios.android.data.database.ItemCursor;
+import com.ghstudios.android.data.database.MonsterEquipmentCursor;
+import com.ghstudios.android.data.database.S;
 import com.ghstudios.android.loader.MonsterEquipmentListCursorLoader;
 import com.ghstudios.android.mhgendatabase.R;
 import com.ghstudios.android.ui.ClickListeners.ArmorClickListener;
@@ -26,6 +29,7 @@ import com.ghstudios.android.ui.ClickListeners.ItemClickListener;
 import com.ghstudios.android.ui.ClickListeners.MaterialClickListener;
 import com.ghstudios.android.ui.ClickListeners.PalicoWeaponClickListener;
 import com.ghstudios.android.ui.ClickListeners.WeaponClickListener;
+import com.github.monxalo.android.widget.SectionCursorAdapter;
 
 import java.io.IOException;
 
@@ -69,7 +73,7 @@ public class MonsterEquipmentFragment extends ListFragment implements
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor cursor) {
         MonsterEquipmentCursorAdapter adapter = new MonsterEquipmentCursorAdapter(
-                getActivity(), cursor);
+                getActivity(), (MonsterEquipmentCursor) cursor);
         setListAdapter(adapter);
     }
 
@@ -78,13 +82,12 @@ public class MonsterEquipmentFragment extends ListFragment implements
         setListAdapter(null);
     }
 
-    private static class MonsterEquipmentCursorAdapter extends CursorAdapter {
-        ItemCursor mItemCursor;
+    private static class MonsterEquipmentCursorAdapter extends SectionCursorAdapter {
+        MonsterEquipmentCursor mEquipmentCursor;
 
-        public MonsterEquipmentCursorAdapter(Context context, Cursor cursor) {
-            //super(context, cursor, R.layout.listview_generic_header, cursor.getColumnIndex(S.COLUMN_COMPONENTS_TYPE));
-            super(context, cursor, 0);
-            mItemCursor = (ItemCursor)cursor;
+        public MonsterEquipmentCursorAdapter(Context context, MonsterEquipmentCursor cursor) {
+            super(context, cursor, R.layout.listview_generic_header, S.COLUMN_HUNTING_REWARDS_RANK);
+            mEquipmentCursor = cursor;
         }
 
         @Override
@@ -98,7 +101,8 @@ public class MonsterEquipmentFragment extends ListFragment implements
         @Override
         public void bindView(View view, Context context, Cursor cursor) {
             // Get the item for the current row
-            Item item = mItemCursor.getItem();
+            MonsterEquipment monsterEquipment = mEquipmentCursor.getMonsterItem();
+            Item item = monsterEquipment.getItem();
 
             // Set up the text view
             LinearLayout clickView = (LinearLayout) view.findViewById(R.id.listitem);

--- a/app/src/main/java/com/ghstudios/android/ui/detail/MonsterEquipmentFragment.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/MonsterEquipmentFragment.java
@@ -1,0 +1,128 @@
+package com.ghstudios.android.ui.detail;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.database.Cursor;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.v4.app.ListFragment;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.Loader;
+import android.support.v4.widget.CursorAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.ghstudios.android.data.classes.Item;
+import com.ghstudios.android.data.database.ItemCursor;
+import com.ghstudios.android.loader.MonsterEquipmentListCursorLoader;
+import com.ghstudios.android.mhgendatabase.R;
+import com.ghstudios.android.ui.ClickListeners.ArmorClickListener;
+import com.ghstudios.android.ui.ClickListeners.DecorationClickListener;
+import com.ghstudios.android.ui.ClickListeners.ItemClickListener;
+import com.ghstudios.android.ui.ClickListeners.MaterialClickListener;
+import com.ghstudios.android.ui.ClickListeners.PalicoWeaponClickListener;
+import com.ghstudios.android.ui.ClickListeners.WeaponClickListener;
+
+import java.io.IOException;
+
+/**
+ * Created by Carlos on 8/21/2016.
+ */
+public class MonsterEquipmentFragment extends ListFragment implements
+        LoaderManager.LoaderCallbacks<Cursor> {
+    private static final String ARG_MONSTER_ID = "MONSTER_ID";
+
+    public static MonsterEquipmentFragment newInstance(long monsterId) {
+        Bundle args = new Bundle();
+        args.putLong(ARG_MONSTER_ID, monsterId);
+        MonsterEquipmentFragment f = new MonsterEquipmentFragment();
+        f.setArguments(args);
+        return f;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Initialize the loader to load the list of runs
+        getLoaderManager().initLoader(R.id.item_list_fragment, getArguments(), this);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_generic_list, null);
+        return v;
+    }
+
+    @SuppressLint("NewApi")
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        long monsterId = args.getLong(ARG_MONSTER_ID, -1);
+        return new MonsterEquipmentListCursorLoader(getActivity(), monsterId);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor cursor) {
+        MonsterEquipmentCursorAdapter adapter = new MonsterEquipmentCursorAdapter(
+                getActivity(), cursor);
+        setListAdapter(adapter);
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+        setListAdapter(null);
+    }
+
+    private static class MonsterEquipmentCursorAdapter extends CursorAdapter {
+        ItemCursor mItemCursor;
+
+        public MonsterEquipmentCursorAdapter(Context context, Cursor cursor) {
+            //super(context, cursor, R.layout.listview_generic_header, cursor.getColumnIndex(S.COLUMN_COMPONENTS_TYPE));
+            super(context, cursor, 0);
+            mItemCursor = (ItemCursor)cursor;
+        }
+
+        @Override
+        public View newView(Context context, Cursor cursor, ViewGroup parent) {
+            LayoutInflater inflater = (LayoutInflater) context
+                    .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            return inflater.inflate(R.layout.fragment_item_listitem,
+                    parent, false);
+        }
+
+        @Override
+        public void bindView(View view, Context context, Cursor cursor) {
+            // Get the item for the current row
+            Item item = mItemCursor.getItem();
+
+            // Set up the text view
+            LinearLayout clickView = (LinearLayout) view.findViewById(R.id.listitem);
+
+            TextView itemNameTextView = (TextView) view.findViewById(R.id.text1);
+            ImageView itemImageView = (ImageView) view.findViewById(R.id.icon);
+
+            String cellText = item.getName();
+            String cellImage = item.getItemImage();
+
+            itemNameTextView.setText(cellText);
+
+            Drawable itemImage = null;
+
+            try {
+                itemImage = Drawable.createFromStream(
+                        context.getAssets().open(cellImage), null);
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+
+            itemImageView.setImageDrawable(itemImage);
+            clickView.setOnClickListener(new ItemClickListener(context, item));
+        }
+    }
+}


### PR DESCRIPTION
This is a work in progress and is yet not ready to merge, but a pull request has been created for review and discussion.

The idea was to be able to see at a glance what equipment can be made from a monster's parts. For example: A person dragged by his or her friends into a Tigrex hunt would be able to see if there's anything they could gain from the hunt at a glance.

However, the current version does not fully satisfy this use case. For example, it does not differentiate between hunting ranks. I also feel that maybe a small bit of information about the weapon or armor should be shown, but I may be wrong.

Current in-progress version:
![image](https://cloud.githubusercontent.com/assets/1286721/22263708/5a6fd1c4-e243-11e6-8491-c668ab1d3519.png)
