### PR TITLE
Removed outer list view from fragment_ailment_listitem.xml

### DIFF
--- a/app/src/main/java/com/ghstudios/android/ui/detail/MonsterSummaryFragment.java
+++ b/app/src/main/java/com/ghstudios/android/ui/detail/MonsterSummaryFragment.java
@@ -459,7 +459,7 @@ public class MonsterSummaryFragment extends Fragment {
 
             // mAilmentsLinearLayout should be the vertical LinearLayout that you substituted the listview with
             for(int i=0;i<adapter.getCount();i++) {
-                LinearLayout v = (LinearLayout) adapter.getView(i, null, mAilments);
+                View v = adapter.getView(i, null, mAilments);
                 mAilments.addView(v);
             }
 

--- a/app/src/main/res/layout/fragment_ailment_listitem.xml
+++ b/app/src/main/res/layout/fragment_ailment_listitem.xml
@@ -1,21 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/listitem"
-    style="@style/list_item"
-    android:layout_height="20dp"
-    android:paddingLeft="0dp"
-    android:orientation="horizontal"
-    android:clickable="false">
-
-    <TextView
-        android:id="@+id/ailment_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center_vertical"
-        style="@style/text_small"
-        android:textColor="@color/text_color_secondary"
-        tools:text="Severe Waterblight"/>
-
-</LinearLayout>
+    android:clickable="false"
+    android:id="@+id/ailment_text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    style="@style/text_small"
+    android:textColor="@color/text_color_secondary"
+    tools:text="Severe Waterblight">
+</TextView>


### PR DESCRIPTION
While fixing the minor UI issue, I also removed the outer linear layout since it was just a layer that wasn't needed. Screenshot 1 is the current version. Screenshot 2 is the updated UI. I haven't touched the database in this PR since @JosephMichels said he'd cover that :)

Screenshots: http://imgur.com/a/eBzHA