### PR TITLE
Add tooltip to weapon, armors, status and weakness icons

### DIFF
--- a/app/src/main/java/com/ghstudios/android/AssetLoader.kt
+++ b/app/src/main/java/com/ghstudios/android/AssetLoader.kt
@@ -57,7 +57,7 @@ object AssetLoader {
      */
     @JvmStatic
     fun loadIconFor(element: ElementStatus): Drawable? {
-        val resId = ElementRegistry.get(element, default=R.color.transparent)
+        val resId = ElementRegistry.get(element, default= ElementStatusInfoNone).icon
         return ctx.getDrawableCompat(resId)
     }
 

--- a/app/src/main/java/com/ghstudios/android/AssetRegistry.kt
+++ b/app/src/main/java/com/ghstudios/android/AssetRegistry.kt
@@ -1,7 +1,10 @@
 @file:JvmName("AssetRegistry")
 package com.ghstudios.android
 
+import android.content.res.Resources
 import android.util.Log
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.ghstudios.android.data.classes.ElementStatus
 import com.ghstudios.android.mhgendatabase.R
 
@@ -12,7 +15,7 @@ import com.ghstudios.android.mhgendatabase.R
  * @param K Type for Value
  */
 
-typealias AdderFun<T, K> = (name: T, resId: K) -> Unit
+typealias AdderFun<T, K> = (name: T, value: K) -> Unit
 
 class Registry<T, K>(val source: Map<T, K>) {
     operator fun get(key: T): K? {
@@ -35,25 +38,35 @@ private fun <T, K> createRegistry(initLambda: (AdderFun<T, K>) -> Unit): Registr
     return Registry(mutableRegistry)
 }
 
+data class ElementStatusInfo(
+    val name: String,
+    @StringRes val tooltipText: Int,
+    @DrawableRes val icon: Int
+)
+
+val ElementStatusInfoNone = ElementStatusInfo(ElementStatus.NONE.name, 0, R.color.transparent)
 
 /**
  * A mapping from an element/status enumeration to a drawable resource
  */
-val ElementRegistry = createRegistry<ElementStatus, Int> { register ->
-    register(ElementStatus.NONE, R.color.transparent)
+val ElementRegistry = createRegistry<ElementStatus, ElementStatusInfo> { register ->
+    fun registerElement(elementStatus: ElementStatus, @DrawableRes icon: Int, @StringRes tooltipText: Int) {
+        register(elementStatus, ElementStatusInfo(elementStatus.name, tooltipText, icon))
+    }
+    register(ElementStatus.NONE, ElementStatusInfoNone)
 
-    register(ElementStatus.FIRE, R.drawable.element_fire)
-    register(ElementStatus.WATER, R.drawable.element_water)
-    register(ElementStatus.THUNDER, R.drawable.element_thunder)
-    register(ElementStatus.ICE, R.drawable.element_ice)
-    register(ElementStatus.DRAGON, R.drawable.element_dragon)
+    registerElement(ElementStatus.FIRE, R.drawable.element_fire, R.string.element_status_tooltip_fire)
+    registerElement(ElementStatus.WATER, R.drawable.element_water, R.string.element_status_tooltip_water)
+    registerElement(ElementStatus.THUNDER, R.drawable.element_thunder, R.string.element_status_tooltip_thunder)
+    registerElement(ElementStatus.ICE, R.drawable.element_ice, R.string.element_status_tooltip_ice)
+    registerElement(ElementStatus.DRAGON, R.drawable.element_dragon, R.string.element_status_tooltip_dragon)
 
-    register(ElementStatus.POISON, R.drawable.status_poison)
-    register(ElementStatus.PARALYSIS, R.drawable.status_paralysis)
-    register(ElementStatus.SLEEP, R.drawable.status_sleep)
-    register(ElementStatus.BLAST, R.drawable.status_blastblight)
-    register(ElementStatus.MOUNT, R.drawable.status_mount)
-    register(ElementStatus.EXHAUST, R.drawable.status_exhaust)
-    register(ElementStatus.JUMP, R.drawable.status_jump)
-    register(ElementStatus.STUN, R.drawable.status_stun)
+    registerElement(ElementStatus.POISON, R.drawable.status_poison, R.string.element_status_tooltip_poison)
+    registerElement(ElementStatus.PARALYSIS, R.drawable.status_paralysis, R.string.element_status_tooltip_paralysis)
+    registerElement(ElementStatus.SLEEP, R.drawable.status_sleep, R.string.element_status_tooltip_sleep)
+    registerElement(ElementStatus.BLAST, R.drawable.status_blastblight, R.string.element_status_tooltip_blastblight)
+    registerElement(ElementStatus.MOUNT, R.drawable.status_mount, R.string.element_status_tooltip_mount)
+    registerElement(ElementStatus.EXHAUST, R.drawable.status_exhaust, R.string.element_status_tooltip_exhaust)
+    registerElement(ElementStatus.JUMP, R.drawable.status_jump, R.string.element_status_tooltip_jump)
+    registerElement(ElementStatus.STUN, R.drawable.status_stun, R.string.element_status_tooltip_stun)
 }

--- a/app/src/main/java/com/ghstudios/android/features/armorsetbuilder/detail/ASBSkillsListFragment.kt
+++ b/app/src/main/java/com/ghstudios/android/features/armorsetbuilder/detail/ASBSkillsListFragment.kt
@@ -12,12 +12,14 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.ListView
 import android.widget.TextView
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.ViewModelProvider
 import com.ghstudios.android.data.classes.ASBSession
 import com.ghstudios.android.mhgendatabase.R
 import com.ghstudios.android.ClickListeners.SkillClickListener
 import com.ghstudios.android.data.classes.ArmorSet
 import com.ghstudios.android.features.armorsetbuilder.ArmorSetCalculator
+import com.ghstudios.android.mhgendatabase.databinding.FragmentAsbSkillsListBinding
 
 /**
  * Fragment to display the list of skills granted from an armor set.
@@ -28,9 +30,17 @@ class ASBSkillsListFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val v = inflater.inflate(R.layout.fragment_asb_skills_list, container, false)
+        val binding = FragmentAsbSkillsListBinding.inflate(inflater, container, false).apply {
+            ViewCompat.setTooltipText(weapon, resources.getString(R.string.asb_tooltip_weapon))
+            ViewCompat.setTooltipText(helmet, resources.getString(R.string.asb_tooltip_armor_head))
+            ViewCompat.setTooltipText(body, resources.getString(R.string.asb_tooltip_armor_body))
+            ViewCompat.setTooltipText(arms, resources.getString(R.string.asb_tooltip_armor_arms))
+            ViewCompat.setTooltipText(waist, resources.getString(R.string.asb_tooltip_armor_waist))
+            ViewCompat.setTooltipText(legs, resources.getString(R.string.asb_tooltip_armor_legs))
+            ViewCompat.setTooltipText(talisman, resources.getString(R.string.asb_tooltip_talisman))
+        }
 
-        val listView = v.findViewById<View>(R.id.list) as ListView
+        val listView = binding.list
 
         val session = viewModel.session
         val calculator = ArmorSetCalculator(session)
@@ -43,7 +53,7 @@ class ASBSkillsListFragment : Fragment() {
             adapter.notifyDataSetChanged()
         })
 
-        return v
+        return binding.root
     }
 
     private class ASBSkillsAdapter(

--- a/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterDamageFragment.kt
+++ b/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterDamageFragment.kt
@@ -187,7 +187,7 @@ class MonsterDamageFragment : Fragment() {
 
             // Check which image to load
             val element = currentStatus.statusEnum
-            val imageFile = ElementRegistry.get(element, R.color.transparent)
+            val elementStatusInfo = ElementRegistry.get(element, ElementStatusInfoNone)
 
             // initialize our views
             initialView.text = initial
@@ -196,12 +196,11 @@ class MonsterDamageFragment : Fragment() {
             durationView.text = duration
             damageView.text = damage
 
-            if (imageFile != -1) {
-                val draw = ContextCompat.getDrawable(context!!, imageFile)
-                val layoutParams = statusImage.layoutParams
-                statusImage.layoutParams = layoutParams
-                statusImage.setImageDrawable(draw)
-            }
+            val draw = ContextCompat.getDrawable(context!!, elementStatusInfo.icon)
+            val layoutParams = statusImage.layoutParams
+            statusImage.layoutParams = layoutParams
+            statusImage.setImageDrawable(draw)
+            ViewCompat.setTooltipText(statusImage, resources.getString(elementStatusInfo.tooltipText))
 
             binding.statusData.addView(wdRow)
         }

--- a/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterDamageFragment.kt
+++ b/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterDamageFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.ViewModelProvider
 
 import com.ghstudios.android.*
@@ -44,6 +45,18 @@ class MonsterDamageFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        with(binding) {
+            ViewCompat.setTooltipText(cut, resources.getString(R.string.monster_tooltip_damage_cut))
+            ViewCompat.setTooltipText(impact, resources.getString(R.string.monster_tooltip_damage_impact))
+            ViewCompat.setTooltipText(shot, resources.getString(R.string.monster_tooltip_damage_shot))
+            ViewCompat.setTooltipText(ko, resources.getString(R.string.monster_tooltip_damage_stun))
+            ViewCompat.setTooltipText(fire, resources.getString(R.string.monster_tooltip_damage_fire))
+            ViewCompat.setTooltipText(water, resources.getString(R.string.monster_tooltip_damage_water))
+            ViewCompat.setTooltipText(ice, resources.getString(R.string.monster_tooltip_damage_ice))
+            ViewCompat.setTooltipText(thunder, resources.getString(R.string.monster_tooltip_damage_thunder))
+            ViewCompat.setTooltipText(dragon, resources.getString(R.string.monster_tooltip_damage_dragon))
+        }
+
         val viewModel = ViewModelProvider(activity!!).get(MonsterDetailViewModel::class.java)
 
         viewModel.monsterData.observe(viewLifecycleOwner, Observer { monster ->

--- a/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterSummaryFragment.kt
+++ b/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterSummaryFragment.kt
@@ -143,16 +143,16 @@ class MonsterSummaryFragment : Fragment() {
 
         // weakness line (element part)
         for (value in mWeakness.element) {
-            val imagePath = ElementRegistry[value.type]
+            val elementStatusInfo = ElementRegistry[value.type]
             val imageModification = imageFromWeaknessRating(value.rating)
-            addIcon(weaknessListView, imagePath, imageModification)
+            addIcon(weaknessListView, elementStatusInfo?.icon, imageModification, elementStatusInfo?.tooltipText)
         }
 
         // weakness line (status part)
         for (value in mWeakness.status) {
-            val imagePath = ElementRegistry[value.type]
+            val elementStatusInfo = ElementRegistry[value.type]
             val imageModification = imageFromWeaknessRating(value.rating)
-            addIcon(weaknessListView, imagePath, imageModification)
+            addIcon(weaknessListView, elementStatusInfo?.icon, imageModification, elementStatusInfo?.tooltipText)
         }
 
         // items line
@@ -165,8 +165,16 @@ class MonsterSummaryFragment : Fragment() {
                 WeaknessType.SONIC_BOMB -> R.drawable.item_bomb_sonic
                 WeaknessType.DUNG_BOMB -> R.drawable.item_bomb_dung
             }
+            val tooltip = when(trapType) {
+                WeaknessType.PITFALL_TRAP -> R.string.weakness_tooltip_pitfall_trap
+                WeaknessType.SHOCK_TRAP -> R.string.weakness_tooltip_shock_trap
+                WeaknessType.MEAT -> R.string.weakness_tooltip_meat
+                WeaknessType.FLASH_BOMB -> R.string.weakness_tooltip_flash_bomb
+                WeaknessType.SONIC_BOMB -> R.string.weakness_tooltip_sonic_bomb
+                WeaknessType.DUNG_BOMB -> R.string.weakness_tooltip_dung_bomb
+            }
 
-            addIcon(itemListView, imagePath, null)
+            addIcon(itemListView, imagePath, null, tooltip)
         }
 
         binding.monsterStateList.addView(weaknessView)
@@ -234,7 +242,7 @@ class MonsterSummaryFragment : Fragment() {
     }
 
     // Add small_icon to a particular LinearLayout
-    private fun addIcon(parentview: ViewGroup, @DrawableRes image: Int?, @DrawableRes mod: Int?) {
+    private fun addIcon(parentview: ViewGroup, @DrawableRes image: Int?, @DrawableRes mod: Int?, @StringRes tooltipText: Int?) {
         if (image == null) {
             Log.e(TAG, "Tried to add null image as an icon")
             return
@@ -251,6 +259,9 @@ class MonsterSummaryFragment : Fragment() {
         // Open Image
         val mainImage = ContextCompat.getDrawable(context!!, image)
         mImage.setImageDrawable(mainImage)
+        tooltipText?.let {
+            ViewCompat.setTooltipText(mImage, resources.getString(tooltipText))
+        }
 
         // Open Image Mod if applicable
         if (mod != null) {

--- a/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterSummaryFragment.kt
+++ b/app/src/main/java/com/ghstudios/android/features/monsters/detail/MonsterSummaryFragment.kt
@@ -11,14 +11,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.view.ViewCompat
 import androidx.lifecycle.ViewModelProvider
 
 import com.ghstudios.android.ClickListeners.LocationClickListener
 import com.ghstudios.android.components.SectionHeaderCell
-import com.ghstudios.android.components.TitleBarCell
 import com.ghstudios.android.mhgendatabase.R
 
 import com.ghstudios.android.*

--- a/app/src/main/java/com/ghstudios/android/features/palicos/PalicoWeaponListFragment.java
+++ b/app/src/main/java/com/ghstudios/android/features/palicos/PalicoWeaponListFragment.java
@@ -141,7 +141,7 @@ public class PalicoWeaponListFragment extends ListFragment implements
                 element_melee_text.setText(Integer.toString(wep.getElementMelee()));
                 element_ranged_text.setText(Integer.toString(wep.getElementRanged()));
 
-                int elementIconId = AssetRegistry.getElementRegistry().get(wep.getElementEnum());
+                int elementIconId = AssetRegistry.getElementRegistry().get(wep.getElementEnum()).getIcon();
                 Drawable elementIcon = ContextCompat.getDrawable(context, elementIconId);
 
                 element_melee.setImageDrawable(elementIcon);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -342,4 +342,29 @@
     <string name="weapon_shelling">Geschossart</string>
     <string name="coating_elemental">Element</string>
     <string name="gather_site_fishing_burst">Angeln (Berstköder)</string>
+
+    <string name="asb_tooltip_weapon">Waffe</string>
+    <string name="asb_tooltip_armor_head">Kopf</string>
+    <string name="asb_tooltip_armor_body">Körper</string>
+    <string name="asb_tooltip_armor_arms">Arme</string>
+    <string name="asb_tooltip_armor_waist">Hüfte</string>
+    <string name="asb_tooltip_armor_legs">Beine</string>
+    <string name="asb_tooltip_talisman">Talisman</string>
+
+    <string name="monster_tooltip_damage_impact">Aufprall</string>
+    <string name="monster_tooltip_damage_fire">Feuer</string>
+    <string name="monster_tooltip_damage_water">Wasser</string>
+    <string name="monster_tooltip_damage_ice">Eis</string>
+    <string name="monster_tooltip_damage_thunder">Donner</string>
+    <string name="monster_tooltip_damage_dragon">Drachen</string>
+
+    <string name="element_status_tooltip_fire">Feuer</string>
+    <string name="element_status_tooltip_water">Wasser</string>
+    <string name="element_status_tooltip_thunder">Donner</string>
+    <string name="element_status_tooltip_ice">Eis</string>
+    <string name="element_status_tooltip_dragon">Drachen</string>
+
+    <string name="element_status_tooltip_poison">Gift</string>
+    <string name="element_status_tooltip_paralysis">Lähmung</string>
+    <string name="element_status_tooltip_exhaust">Erschöpfung</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -466,4 +466,29 @@
         <item>Artillero</item>
     </string-array>
 
+    <string name="asb_tooltip_weapon">Arma</string>
+    <string name="asb_tooltip_armor_head">Cabeza</string>
+    <string name="asb_tooltip_armor_body">Pecho</string>
+    <string name="asb_tooltip_armor_arms">Brazos</string>
+    <string name="asb_tooltip_armor_waist">Cintura</string>
+    <string name="asb_tooltip_armor_legs">Piernas</string>
+    <string name="asb_tooltip_talisman">Amuleto</string>
+
+    <string name="monster_tooltip_damage_impact">Impacto</string>
+    <string name="monster_tooltip_damage_fire">Fuego</string>
+    <string name="monster_tooltip_damage_water">Agua</string>
+    <string name="monster_tooltip_damage_ice">Hielo</string>
+    <string name="monster_tooltip_damage_thunder">Trueno</string>
+    <string name="monster_tooltip_damage_dragon">Dragón</string>
+
+    <string name="element_status_tooltip_fire">Fuego</string>
+    <string name="element_status_tooltip_water">Agua</string>
+    <string name="element_status_tooltip_thunder">Trueno</string>
+    <string name="element_status_tooltip_ice">Hielo</string>
+    <string name="element_status_tooltip_dragon">Dragón</string>
+
+    <string name="element_status_tooltip_poison">Veneno</string>
+    <string name="element_status_tooltip_paralysis">Parálisis</string>
+    <string name="element_status_tooltip_exhaust">Fatiga</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,16 @@
     <string name="monster_status_duration">Duration</string>
     <string name="monster_status_damage">Damage</string>
 
+    <string name="monster_tooltip_damage_cut">Cut</string>
+    <string name="monster_tooltip_damage_impact">Impact</string>
+    <string name="monster_tooltip_damage_shot">Shot</string>
+    <string name="monster_tooltip_damage_stun">Stun</string>
+    <string name="monster_tooltip_damage_fire">Fire</string>
+    <string name="monster_tooltip_damage_water">Water</string>
+    <string name="monster_tooltip_damage_ice">Ice</string>
+    <string name="monster_tooltip_damage_thunder">Thunder</string>
+    <string name="monster_tooltip_damage_dragon">Dragon</string>
+
     <!-- Items -->
     <string name="item_detail_tab_detail">Detail</string>
     <string name="item_detail_tab_usage">Usage</string>
@@ -345,6 +355,25 @@
     <string name="weapon_melody_duration">DUR: %s</string>
     <string name="weapon_melody_extension">EXT: %s</string>
 
+    <string name="element_status_tooltip_fire">Fire</string>
+    <string name="element_status_tooltip_water">Water</string>
+    <string name="element_status_tooltip_thunder">Thunder</string>
+    <string name="element_status_tooltip_ice">Ice</string>
+    <string name="element_status_tooltip_dragon">Dragon</string>
+    <string name="element_status_tooltip_poison">Poison</string>
+    <string name="element_status_tooltip_paralysis">Paralysis</string>
+    <string name="element_status_tooltip_sleep">Sleep</string>
+    <string name="element_status_tooltip_blastblight">Blastblight</string>
+    <string name="element_status_tooltip_mount">Mount</string>
+    <string name="element_status_tooltip_exhaust">Exhaust</string>
+    <string name="element_status_tooltip_jump">Jump</string>
+    <string name="element_status_tooltip_stun">Stun</string>
+    <string name="weakness_tooltip_pitfall_trap">Pitfall trap</string>
+    <string name="weakness_tooltip_shock_trap">Shock trap</string>
+    <string name="weakness_tooltip_meat">Meat</string>
+    <string name="weakness_tooltip_flash_bomb">Flash bomb</string>
+    <string name="weakness_tooltip_sonic_bomb">Sonic bomb</string>
+    <string name="weakness_tooltip_dung_bomb">Dung bomb</string>
 
     <!-- Palicos -->
     <string name="palico_equipment_tab_detail">Detail</string>
@@ -432,6 +461,14 @@
     <string name="asb_weapon_slots_one">Weapon (One Slots)</string>
     <string name="asb_weapon_slots_two">Weapon (Two Slots)</string>
     <string name="asb_weapon_slots_three">Weapon (Three Slots)</string>
+
+    <string name="asb_tooltip_weapon">Weapon</string>
+    <string name="asb_tooltip_armor_head">Head</string>
+    <string name="asb_tooltip_armor_body">Body</string>
+    <string name="asb_tooltip_armor_arms">Arms</string>
+    <string name="asb_tooltip_armor_waist">Waist</string>
+    <string name="asb_tooltip_armor_legs">Legs</string>
+    <string name="asb_tooltip_talisman">Talisman</string>
 
     <!-- Bowgun strings -->
     <string name="siege_mode">Siege Mode</string>


### PR DESCRIPTION
Icons are great but when you are not familiar with the game their meaning is unknown. 
Add a tooltip for icons when they are used as table header or to express a value. A long press on the icon will show the tooltip. 